### PR TITLE
Update NegotiationView dinamically

### DIFF
--- a/client/app/controllers/NegociacaoController.js
+++ b/client/app/controllers/NegociacaoController.js
@@ -7,7 +7,15 @@ class NegociacaoController {
     this._inputQuantity = $('#quantity');
     this._inputValue = $('#value');
 
-    this._negotiations = new Negotiations();
+    // The arrow function has a static this. Its context is obtained
+    // from the code arround.
+    this._negotiations = new Negotiations(model => {
+      // The this here refers to the NegociacaoController.
+      // The reason is the arrow function.
+      // A function (){} declaration obtains the this dinamically.
+      this._negotiationsView.update(model);
+    });
+
     this._negotiationsView = new NegotiationsView('#negotiations');
 
     this._message = new Message();
@@ -30,7 +38,6 @@ class NegociacaoController {
 
     this._negotiationsView.update(this._negotiations);
     this._message.text = 'You made a new negotiation!';
-    this._messageView.update(this._message);
 
     this._cleanForm();
   }
@@ -47,7 +54,6 @@ class NegociacaoController {
     this._negotiations.clearList();
     this._message.text = 'Negotiation list is empty!';
     this._messageView.update(this._message);
-    this._negotiationsView.update(this._negotiations);
   }
 
   _cleanForm() {

--- a/client/app/domain/negociacao/Negotiations.js
+++ b/client/app/domain/negociacao/Negotiations.js
@@ -1,14 +1,17 @@
 class Negotiations {
-  constructor() {
+  constructor(hook) {
     this._negotiations = [];
+    this._hook = hook;
   }
 
   add(negotiation) {
     this._negotiations.push(negotiation);
+    this._hook(this);
   }
 
   clearList() {
     return this._negotiations = [];
+    this._hook(this);
   }
 
   toArray() {


### PR DESCRIPTION
This strategy uses a hook as a function called every time a method in the model whose effect alter its initial state is called. It is very close to react library strategy.
This is the firts approach adding a variable self in the controller context to fix the "this" wrong reference in runtime execution. The book will also propose another strategy.
...................
The conclusion, the strategy above is not the best one. The objective is to show how the arrow function is used and its difference from `function(){}`, which changes the `this` depending on the object responsible for its call.