### PR TITLE
cap11.2 - Introduction to W3C for date input

### DIFF
--- a/client/app/ui/converters/DateConverter.js
+++ b/client/app/ui/converters/DateConverter.js
@@ -8,11 +8,12 @@ class DateConverter {
   }
 
   static  toDate(string) {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(string))
-      throw new Error('Wrong format. Must be aaaa-mm-dd');
+    if (!/^\d{2}\/\d{2}\/\d{4}$/.test(string))
+      throw new Error('Wrong format. Must be aaaa/mm/dd');
 
-    return new Date(...string.split('-')
-           .map((item, index) => item - index % 2)
+    return new Date(...string.split('/')
+          .reverse()
+          .map((item, index) => item - index % 2)
     );
 
   }

--- a/client/index.html
+++ b/client/index.html
@@ -15,7 +15,7 @@
         
         <div class="form-group">
             <label for="data">Data</label>
-            <input type="date" id="date" class="form-control" required autofocus/>        
+            <input type="text" id="date" class="form-control" required autofocus/>        
         </div>    
         
         <div class="form-group">


### PR DESCRIPTION
It is said at [W3C](https://www.w3.org/TR/2012/WD-html-markup-20120329/input.date.html) that the format YYYY-MM-DD works for modern browsers such as Chrome, Firefox. However it will fallback to text on Internet Explorer and Android prior to 6.6.
Note: the input became a text in Brave Browser.