### PR TITLE
Cap15.5 Mokey Patch

### DIFF
--- a/client/app/util/ConnectionFactory.js
+++ b/client/app/util/ConnectionFactory.js
@@ -44,5 +44,9 @@ const ConnectionFactory = ( () => {
         connection.createObjectStore(store, { autoIncrement: true })
       });
     }
+
+    static closeConnection(){
+      if (connection) connection.close()
+    }
   }
 })();

--- a/client/app/util/ConnectionFactory.js
+++ b/client/app/util/ConnectionFactory.js
@@ -22,6 +22,9 @@ const ConnectionFactory = ( () => {
 
         openRequest.onsuccess = e => {
           connection = e.target.result;
+          connection.close = () => {
+            throw new Error('This connection can not be closed directly');
+          }
           resolve(e.target.result);
         };
 

--- a/client/app/util/ConnectionFactory.js
+++ b/client/app/util/ConnectionFactory.js
@@ -2,6 +2,7 @@ const ConnectionFactory = ( () => {
 
   const stores = ['negotiations'];
   let connection = null;
+  let close = null;
 
   return class ConnectionFactory {
     constructor(){
@@ -22,6 +23,7 @@ const ConnectionFactory = ( () => {
 
         openRequest.onsuccess = e => {
           connection = e.target.result;
+          close = connection.close.bind(connection);
           connection.close = () => {
             throw new Error('This connection can not be closed directly');
           }
@@ -46,7 +48,7 @@ const ConnectionFactory = ( () => {
     }
 
     static closeConnection(){
-      if (connection) connection.close()
+      if (connection) close()
     }
   }
 })();


### PR DESCRIPTION
We do not want to close the connection directly.
We create a monkey patch to hide the original `close()` from `ConnectionFactory`, however we needed previously to hold the original function in a variable bind by the `ConnectionFactory` context.