### PR TITLE
Add babel watch script to js package json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "babel app-src -d app --source-maps"
+    "build": "babel app-src -d app --source-maps",
+    "watch": "babel app-src -d app --source-maps --watch"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
On running npm run watch will watch the js files for any modification. It avoids running npm run build avery time a js file is modified.
Vide new babel [cli version setup](https://babeljs.io/docs/babel-cli)